### PR TITLE
Optimize CombatLogEventUnfiltered logic

### DIFF
--- a/GogoWatch.lua
+++ b/GogoWatch.lua
@@ -43,7 +43,7 @@ function GogoWatch.Events:CombatLogEventUnfiltered(...)
                     local Strings = GogoWatch.Strings
                     local castLevel, castString = nil, nil
                     if curSpell.LevelBase == "Self" then
-                        castLevel = UnitLevel("Player")
+                        castLevel = UnitLevel(sourceName)
                         castString = Strings.SelfCast
                     elseif curSpell.LevelBase == "Target" then
                         castLevel = UnitLevel(destName)


### PR DESCRIPTION
Incorporates #20

- Avoid allocating unused variable `spellName`
- Reduce unneeded nesting
- Evaluate exit conditions as early as possible
- Limit `InGroupWith` loops to current group/raid members rather than assuming full Azeroth raid roster
