### PR TITLE
set castlevel from sourceName

### DIFF
--- a/GogoWatch.lua
+++ b/GogoWatch.lua
@@ -46,7 +46,7 @@ function GogoWatch.Events:CombatLogEventUnfiltered(...)
                     local Strings = GogoWatch.Strings
                     local castLevel, castString = nil, nil
                     if curSpell.LevelBase == "Self" then
-                        castLevel = UnitLevel("Player")
+                        castLevel = UnitLevel(sourceName)
                         castString = Strings.SelfCast
                     elseif curSpell.LevelBase == "Target" then
                         castLevel = UnitLevel(destName)


### PR DESCRIPTION
Set castlevel from sourceName instead of always using the "player" level. This fixes an issue where when grouped with players of a different level, GoGoWatch may ignore down ranks from higher level party members or false report for lower level party members.

Also some whitespace changes from the web editor through github.